### PR TITLE
Add specifying keepalived image in crd

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ kind: KeepalivedGroup
 metadata:
   name: keepalivedgroup-router
 spec:
+  image: registry.redhat.io/openshift4/ose-keepalived-ipfailover
   interface: ens3
   nodeSelector:
     node-role.kubernetes.io/loadbalancer: ""
@@ -38,6 +39,8 @@ This KeepalivedGroup will be deployed on all the nodes with role `loadbalancer`.
 Services must be annotated to opt-in to being observed by the keepalived operator and to specify which KeepalivedGroup they refer to. The annotation looks like this:
 
 `keepalived-operator.redhat-cop.io/keepalivedgroup: <keepalivedgroup namespace>/<keepalivedgroup-name>`
+
+The image used for the keepalived containers can be specified with `.Spec.Image` it will default to `registry.redhat.io/openshift4/ose-keepalived-ipfailover` if undefined. 
 
 ## Requirements
 

--- a/build/templates/keepalived-template.yaml
+++ b/build/templates/keepalived-template.yaml
@@ -25,7 +25,7 @@
         shareProcessNamespace: true
         containers:
         - name: keepalived
-          image: "registry.redhat.io/openshift4/ose-keepalived-ipfailover"
+          image: {{ .KeepalivedGroup.Spec.Image }}
           command:
           - /usr/sbin/keepalived
           - -l

--- a/deploy/crds/redhatcop.redhat.io_keepalivedgroups_crd.yaml
+++ b/deploy/crds/redhatcop.redhat.io_keepalivedgroups_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: keepalivedgroups.redhatcop.redhat.io
@@ -10,94 +10,95 @@ spec:
     plural: keepalivedgroups
     singular: keepalivedgroup
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: KeepalivedGroup is the Schema for the keepalivedgroups API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: KeepalivedGroupSpec defines the desired state of KeepalivedGroup
-          properties:
-            interface:
-              type: string
-            nodeSelector:
-              additionalProperties:
-                type: string
-              type: object
-            verbatimConfig:
-              additionalProperties:
-                type: string
-              type: object
-          required:
-          - interface
-          type: object
-        status:
-          description: KeepalivedGroupStatus defines the observed state of KeepalivedGroup
-          properties:
-            conditions:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              items:
-                description: "Condition represents an observation of an object's state.
-                  Conditions are an extension mechanism intended to be used when the
-                  details of an observation are not a priori known or would not apply
-                  to all instances of a given Kind. \n Conditions should be added
-                  to explicitly convey properties that users and components care about
-                  rather than requiring those properties to be inferred from other
-                  observations. Once defined, the meaning of a Condition can not be
-                  changed arbitrarily - it becomes part of the API, and has the same
-                  backwards- and forwards-compatibility concerns of any other part
-                  of the API."
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    description: ConditionReason is intended to be a one-word, CamelCase
-                      representation of the category of cause of the current status.
-                      It is intended to be used in concise output, such as one-line
-                      kubectl get output, and in summarizing occurrences of causes.
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: "ConditionType is the type of the condition and is
-                      typically a CamelCased word or short phrase. \n Condition types
-                      should indicate state in the \"abnormal-true\" polarity. For
-                      example, if the condition indicates when a policy is invalid,
-                      the \"is valid\" case is probably the norm, so the condition
-                      should be called \"Invalid\"."
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            routerIDs:
-              additionalProperties:
-                type: integer
-              type: object
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeepalivedGroup is the Schema for the keepalivedgroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeepalivedGroupSpec defines the desired state of KeepalivedGroup
+            properties:
+              image:
+                type: string
+              interface:
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              verbatimConfig:
+                additionalProperties:
+                  type: string
+                type: object
+            required:
+            - interface
+            type: object
+          status:
+            description: KeepalivedGroupStatus defines the observed state of KeepalivedGroup
+            properties:
+              conditions:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              routerIDs:
+                additionalProperties:
+                  type: integer
+                type: object
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/redhatcop.redhat.io_keepalivedgroups_crd.yaml
+++ b/deploy/crds/redhatcop.redhat.io_keepalivedgroups_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: keepalivedgroups.redhatcop.redhat.io
@@ -10,95 +10,96 @@ spec:
     plural: keepalivedgroups
     singular: keepalivedgroup
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KeepalivedGroup is the Schema for the keepalivedgroups API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KeepalivedGroupSpec defines the desired state of KeepalivedGroup
+          properties:
+            image:
+              type: string
+            interface:
+              type: string
+            nodeSelector:
+              additionalProperties:
+                type: string
+              type: object
+            verbatimConfig:
+              additionalProperties:
+                type: string
+              type: object
+          required:
+          - interface
+          type: object
+        status:
+          description: KeepalivedGroupStatus defines the observed state of KeepalivedGroup
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                description: "Condition represents an observation of an object's state.
+                  Conditions are an extension mechanism intended to be used when the
+                  details of an observation are not a priori known or would not apply
+                  to all instances of a given Kind. \n Conditions should be added
+                  to explicitly convey properties that users and components care about
+                  rather than requiring those properties to be inferred from other
+                  observations. Once defined, the meaning of a Condition can not be
+                  changed arbitrarily - it becomes part of the API, and has the same
+                  backwards- and forwards-compatibility concerns of any other part
+                  of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase
+                      representation of the category of cause of the current status.
+                      It is intended to be used in concise output, such as one-line
+                      kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is
+                      typically a CamelCased word or short phrase. \n Condition types
+                      should indicate state in the \"abnormal-true\" polarity. For
+                      example, if the condition indicates when a policy is invalid,
+                      the \"is valid\" case is probably the norm, so the condition
+                      should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            routerIDs:
+              additionalProperties:
+                type: integer
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: KeepalivedGroup is the Schema for the keepalivedgroups API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KeepalivedGroupSpec defines the desired state of KeepalivedGroup
-            properties:
-              image:
-                type: string
-              interface:
-                type: string
-              nodeSelector:
-                additionalProperties:
-                  type: string
-                type: object
-              verbatimConfig:
-                additionalProperties:
-                  type: string
-                type: object
-            required:
-            - interface
-            type: object
-          status:
-            description: KeepalivedGroupStatus defines the observed state of KeepalivedGroup
-            properties:
-              conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                  code after modifying this file Add custom validation using kubebuilder
-                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-                items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              routerIDs:
-                additionalProperties:
-                  type: integer
-                type: object
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/pkg/apis/redhatcop/v1alpha1/keepalivedgroup_types.go
+++ b/pkg/apis/redhatcop/v1alpha1/keepalivedgroup_types.go
@@ -18,6 +18,9 @@ type KeepalivedGroupSpec struct {
 	// +kubebuilder:validation:Optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	Image string `json:"image,omitempty"`
+
 	// +kubebuilder:validation:Required
 	Interface string `json:"interface"`
 

--- a/pkg/controller/keepalivedgroup/keepalivedgroup_controller.go
+++ b/pkg/controller/keepalivedgroup/keepalivedgroup_controller.go
@@ -337,6 +337,15 @@ func (r *ReconcileKeepalivedGroup) getReferencingServices(instance *redhatcopv1a
 	return result, nil
 }
 
+func (r *ReconcileKeepalivedGroup) IsInitialized(instance *redhatcopv1alpha1.KeepalivedGroup) bool {
+	initialized := true
+	if instance.Spec.Image == "" {
+		instance.Spec.Image = "registry.redhat.io/openshift4/ose-keepalived-ipfailover"
+		initialized = false
+	}
+	return initialized
+}
+
 func initializeTemplate() (*template.Template, error) {
 	templateFileName, ok := os.LookupEnv(templateFileNameEnv)
 	if !ok {


### PR DESCRIPTION
This PR allows users to specify the image used by keepalived pods. Allows disconnected deployments. 