### PR TITLE
Make operator more resilient to pod restarts

### DIFF
--- a/build/templates/keepalived-template.yaml
+++ b/build/templates/keepalived-template.yaml
@@ -27,15 +27,10 @@
         - name: keepalived
           image: {{ .KeepalivedGroup.Spec.Image }}
           command:
-          - /usr/sbin/keepalived
-          - -l
-          - -D
-          - -n
+          - "/bin/sh"
           args:
-          - -f
-          - /etc/keepalived.d/keepalived.conf
-          - -p
-          - /etc/keepalived.pid/keepalived.pid
+          - -c
+          - "pkill -f ^/usr/sbin/keepalived; /usr/sbin/keepalived -l -D -n -f /etc/keepalived.d/keepalived.conf -p /etc/keepalived.pid/keepalived.pid"
           volumeMounts:
           - mountPath: /lib/modules
             name: lib-modules


### PR DESCRIPTION
This pull request updates the template such that pre-emptive measures are taken to clean up any keepalived processes that could still be running. This should be a fix to #24 - Feedback on this approach is welcome