### PR TITLE
Change medium for emptydir pid to save pidfile to memory

### DIFF
--- a/build/templates/keepalived-template.yaml
+++ b/build/templates/keepalived-template.yaml
@@ -27,10 +27,15 @@
         - name: keepalived
           image: {{ .KeepalivedGroup.Spec.Image }}
           command:
-          - "/bin/sh"
+          - /usr/sbin/keepalived
+          - -l
+          - -D
+          - -n
           args:
-          - -c
-          - "pkill -f ^/usr/sbin/keepalived; /usr/sbin/keepalived -l -D -n -f /etc/keepalived.d/keepalived.conf -p /etc/keepalived.pid/keepalived.pid"
+          - -f
+          - /etc/keepalived.d/keepalived.conf
+          - -p
+          - /etc/keepalived.pid/keepalived.pid
           volumeMounts:
           - mountPath: /lib/modules
             name: lib-modules
@@ -94,7 +99,8 @@
           configMap:
             name: {{ .KeepalivedGroup.ObjectMeta.Name }}
         - name: pid
-          emptyDir: {}
+          emptyDir:
+            medium: Memory
         - name: stats
           emptyDir: {}                                
 - apiVersion: v1


### PR DESCRIPTION
This pull request changes the medium for the `emptyDir` volume `pid` to `Memory` To prevent stale pidfiles from causing crashloops when the containers restart but the pod does not. 

This is a much cleaner way of fixing #24 