### PR TITLE
Add annotation to allow spreading VIPs across keepalived instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Additionally, the fields can be edited manually via `oc edit Network.config.open
 If the Keepalived pods are deployed on nodes which are in the same network (same broadcast domain to be precise) with other keepalived the process, it's necessary to ensure that there is no collision between the used routers it.
 For this purpose it is possible to provide a `blacklistRouterIDs` field with a list of black-listed IDs that will not be used.
 
+## Spreading VIPs across nodes to maximize load balancing
+
+If a service contains multiple externalIPs or LoadBalancer IPs, it is possible to instruct keepalived-operator to maximize the spread of such VIPs across the nodes in the KeepalivedGroup by specifying the `keepalived-operator.redhat-cop.io/spreadvips: "true"` annotation on the service. This option ensures that different VIPs for the same service are always owned by different nodes (or, if the number of nodes in the group is less than the number of VIPs, that the VIPs are assigned maximizing the spread), to avoid creating a traffic bottleneck. However, in order to achieve this, keepalived-operator will create a separate VRRP instance per VIP of that service, which could exhaust the 256 available instances faster.
+
 ## OpenShift RHV, vSphere, OSP and bare metal IPI instructions
 
 When IPI is used for RHV, vSphere, OSP or bare metal platforms, three keepalived VIPs are deployed. To make sure that keepalived-operator can work in these environment we need to discover and blacklist the corresponding VRRP router IDs.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - get

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -29,15 +29,22 @@
         - name: keepalived
           image: {{ .KeepalivedGroup.Spec.Image }}
           command:
-          - /usr/sbin/keepalived
-          - -l
-          - -D
-          - -n
+          - /bin/bash
           args:
-          - -f
-          - /etc/keepalived.d/keepalived.conf
-          - -p
-          - /etc/keepalived.pid/keepalived.pid
+          - -c
+          - >
+            exec /usr/sbin/keepalived
+            --log-console
+            --log-detail
+            --dont-fork
+            --config-id=${POD_NAME}
+            --use-file=/etc/keepalived.d/keepalived.conf
+            --pid=/etc/keepalived.pid/keepalived.pid
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           volumeMounts:
           - mountPath: /lib/modules
             name: lib-modules
@@ -134,30 +141,61 @@
     {{- end }}
 
   {{ $root:=. }} 
-  {{ $verbatim_key:="keepalived-operator.redhat-cop.io/verbatimconfig"}}   
-  {{ range .Services }}
-      {{ $namespacedName:=printf "%s/%s" .ObjectMeta.Namespace .ObjectMeta.Name }}
+  {{ $verbatim_key:="keepalived-operator.redhat-cop.io/verbatimconfig"}}  
+  {{ $spread_key:="keepalived-operator.redhat-cop.io/spreadvips" }} 
+  {{ range $service := .Services }}
+      {{ $namespacedName:=printf "%s/%s" $service.ObjectMeta.Namespace $service.ObjectMeta.Name }}
+      {{- if eq (index $service.GetAnnotations $spread_key) "true"}}
+      {{- range $i, $ip := (mergeStringSlices $service.Status.LoadBalancer.Ingress $service.Spec.ExternalIPs) }}
+      {{- $namespacedNameForIP := printf "%s/%s" $namespacedName $ip }}
+      {{- $owner := index $root.KeepalivedPods (modulus $i (len $root.KeepalivedPods)) }}
+      vrrp_instance {{ $namespacedNameForIP }} {
+          @{{ $owner.ObjectMeta.Name }} state MASTER
+          @^{{ $owner.ObjectMeta.Name }} state BACKUP
+          @{{ $owner.ObjectMeta.Name }} priority 200
+          @^{{ $owner.ObjectMeta.Name }} priority 100
+          interface {{ $root.KeepalivedGroup.Spec.Interface }}
+          
+          virtual_router_id {{ index $root.KeepalivedGroup.Status.RouterIDs $namespacedNameForIP }}  
+          
+          virtual_ipaddress {
+            {{ $ip }}
+          }
+
+          {{- if eq $service.Spec.ExternalTrafficPolicy "Local" }}
+          track_script {
+            {{ $namespacedName }}
+          }
+          {{- end }}
+
+          {{ range $key , $value := (parseJson (index $service.GetAnnotations $verbatim_key)) }}
+          {{ $key }} {{ $value }}
+          {{ end }}
+      }
+      {{- end }}
+      {{- else }}
       vrrp_instance {{ $namespacedName }} {
           interface {{ $root.KeepalivedGroup.Spec.Interface }}
           
           virtual_router_id {{ index $root.KeepalivedGroup.Status.RouterIDs $namespacedName }}  
           
           virtual_ipaddress {
-            {{ range mergeStringSlices .Status.LoadBalancer.Ingress .Spec.ExternalIPs }}
+            {{ range mergeStringSlices $service.Status.LoadBalancer.Ingress $service.Spec.ExternalIPs }}
             {{ . }}
             {{ end }}
           }
 
-          {{- if eq .Spec.ExternalTrafficPolicy "Local" }}
+          {{- if eq $service.Spec.ExternalTrafficPolicy "Local" }}
           track_script {
             {{ $namespacedName }}
           }
           {{- end }}
 
-          {{ range $key , $value := (parseJson (index .GetAnnotations $verbatim_key)) }}
+          {{ range $key , $value := (parseJson (index $service.GetAnnotations $verbatim_key)) }}
           {{ $key }} {{ $value }}
           {{ end }}
       }
+      {{- end }}
   {{ end }}
 {{ if eq .Misc.supportsPodMonitor "true" }}
 - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
A common use case for keepalived in environments with higher load is to have multiple VIPs for HA configured in such a way that they are spread across the nodes. This configuration allows for maximum load balancing, for example through DNS round robin, while maintaining HA, as a failure of a node will still result in another node getting ownership of the VIP.

This PR introduces the possibility to specify an extra annotation `keepalived-operator.redhat-cop.io/spreadvips: "true"` on services requesting keepalived-managed IPs, that will instruct keepalived-operator to spread the VIPs of the service across all of the keepalived instances of the KeepalivedGroup. If the annotation is found, keepalived-operator will add extra configs to set a preferred owner for each VIP in the service, using a round-robin algorithm among the keepalived pods. The PR also adds the ability to watch for pod changes, to ensure that any change in the pods backing the daemonset is reflected in the configurations.

This PR aims at being 100% backwards-compatible, by adding this functionality as an opt-in option. Services that do not specify the new annotation will continue to behave as they always have.