### PR TITLE
Handle local externalTrafficPolicy correctly

### DIFF
--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -120,6 +120,19 @@
           {{ $key }} {{ $value }}
 {{ end }}                    
       }
+
+    {{- range $service := .Services }}
+    {{- if eq $service.Spec.ExternalTrafficPolicy "Local" }}
+    {{- $namespacedName := printf "%s/%s" $service.ObjectMeta.Namespace $service.ObjectMeta.Name }}
+      vrrp_script {{ $namespacedName }} {
+        script "/usr/bin/curl --fail --max-time 1 http://127.0.0.1:{{ $service.Spec.HealthCheckNodePort }}/health"
+        timeout 10
+        rise 3
+        fall 3
+      }
+    {{- end }}
+    {{- end }}
+
   {{ $root:=. }} 
   {{ $verbatim_key:="keepalived-operator.redhat-cop.io/verbatimconfig"}}   
   {{ range .Services }}
@@ -134,6 +147,13 @@
             {{ . }}
             {{ end }}
           }
+
+          {{- if eq .Spec.ExternalTrafficPolicy "Local" }}
+          track_script {
+            {{ $namespacedName }}
+          }
+          {{- end }}
+
           {{ range $key , $value := (parseJson (index .GetAnnotations $verbatim_key)) }}
           {{ $key }} {{ $value }}
           {{ end }}


### PR DESCRIPTION
LoadBalancer services can specify an extra property called `externalTrafficPolicy` which defines how kube-proxy sets up the load balancing on the nodes. If such property is set to `Local`, kube-proxy will only forward traffic for externalIPs or LoadBalancer IPs to pods backing the service that are running on the node on which the packet arrived. If no pods are running on that node, that traffic gets dropped.

This PR introduces a vrrp_script for services that set this property to `Local` which will healthcheck the Kubernetes provided health endpoint for the service. This endpoint returns 200 if at least a pod backing the service is running on the node, or 503 if no pods are running on the node. By adding this healthcheck script, keepalived will deem the node unhealthy if the healthcheck fails, thus ensuring the VIP moves to a different owner that does have at least a pod backing the service running on it. This way no traffic will be lost and the `Local` `externalTrafficPolicy` will work as intended.

This PR requires the keepalived image to contain the `/usr/bin/curl` binary which is used to perform the healthcheck.

This PR should address and fix #13 