### PR TITLE
Fix spreadvips bug that leads to KeepalivedGroup unable to start

### DIFF
--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -145,7 +145,7 @@
   {{ $spread_key:="keepalived-operator.redhat-cop.io/spreadvips" }} 
   {{ range $service := .Services }}
       {{ $namespacedName:=printf "%s/%s" $service.ObjectMeta.Namespace $service.ObjectMeta.Name }}
-      {{- if eq (index $service.GetAnnotations $spread_key) "true"}}
+      {{- if and (eq (index $service.GetAnnotations $spread_key) "true") (gt (len $root.KeepalivedPods) 0) }}
       {{- range $i, $ip := (mergeStringSlices $service.Status.LoadBalancer.Ingress $service.Spec.ExternalIPs) }}
       {{- $namespacedNameForIP := printf "%s/%s" $namespacedName $ip }}
       {{- $owner := index $root.KeepalivedPods (modulus $i (len $root.KeepalivedPods)) }}


### PR DESCRIPTION
The introduction of the `spreadvips` annotation introduced a bug where if the KeepalivedGroup CR is deployed while some services already exist targeting it and they all specify the `spreadvips` annotation, the keepalived pods can fail to start.

This is due to the template using the modulus function to assign the preferred owners among the existing keepalived pods. If, however, no keepalived pods exist yet, due to the KeepalivedGroup being new, the template cannot be templated since the modulus function would lead to a division by 0 (the length of the array containing the names of the keepalived pods). Unfortunately, the template is also the one creating said pods, therefore the KeepalivedGroup will remain deadlocked forever.

This PR fixes the issue by defaulting to the old non-spread algorithm if no pods are yet available. This allows the template to be generated, which creates the keepalived pods, which in turns triggers a reconciliation that will correctly switch to the `spreadvips` configuration.