### PR TITLE
Enable interface autodiscovery based on a reachable IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /workspace/notify /usr/local/bin
 COPY --from=builder /workspace/keepalived_exporter /usr/local/bin
 COPY config/templates /templates
 COPY config/docker /usr/local/bin
-RUN yum -y install --disableplugin=subscription-manager kmod sed grep net-tools && yum clean all
+RUN yum -y install --disableplugin=subscription-manager kmod iproute && yum clean all
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /workspace/notify /usr/local/bin
 COPY --from=builder /workspace/keepalived_exporter /usr/local/bin
 COPY config/templates /templates
 COPY config/docker /usr/local/bin
-RUN yum -y install --disableplugin=subscription-manager kmod && yum clean all
+RUN yum -y install --disableplugin=subscription-manager kmod sed grep net-tools && yum clean all
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ spec:
   - 2  
 ```
 
-This KeepalivedGroup will be deployed on all the nodes with role `loadbalancer`. One must also specify the network device on which the VIPs will be exposed, it is assumed that all the nodes have the same network device configuration.
+This KeepalivedGroup will be deployed on all the nodes with role `loadbalancer`. Keepalived requires knowledge of the network device on which the VIPs will be exposed. If the interface name is the same on all nodes, it can be specified in the `interface` field. Alternatively, the `interfaceFromIP` field can be set to an IPv4 address to enable interface autodiscovery. In this scenario, the `interface` field will be ignored and each node in the KeepalivedGroup will expose the VIPs on the interface that would be used to reach the provided IP.
 
 Services must be annotated to opt-in to being observed by the keepalived operator and to specify which KeepalivedGroup they refer to. The annotation looks like this:
 

--- a/api/v1alpha1/keepalivedgroup_types.go
+++ b/api/v1alpha1/keepalivedgroup_types.go
@@ -42,6 +42,10 @@ type KeepalivedGroupSpec struct {
 	Interface string `json:"interface"`
 
 	// +optional
+	// +kubebuilder:validation:Format=ipv4
+	InterfaceFromIP string `json:"interfaceFromIP"`
+
+	// +optional
 	PasswordAuth PasswordAuth `json:"passwordAuth,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
@@ -48,6 +48,9 @@ spec:
                 type: string
               interface:
                 type: string
+              interfaceFromIP:
+                format: ipv4
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/docker/notify.sh
+++ b/config/docker/notify.sh
@@ -3,16 +3,35 @@
 ## $template contains the template to execute
 ## $verb
 
+function set_up_configs {
+  cp $file $dst_file
+  if [ -n "$IFACE" ]; then
+    sed -i "s/interface.*$/interface $IFACE/g" $dst_file
+    echo "autodicovered local interface that can reach $reachip to be $IFACE"
+  fi
+}
+
 set -o nounset
 set -o errexit
 
 HASH=$(md5sum $(readlink -f $file))
+
+IFACE=""
+if [ -n "$reachip" ]; then
+  IFACE=$(ip route get $reachip | awk "/$reachip/{ print \$3 }")
+fi
+
+if [ "$setup" = "true" ]; then
+  set_up_configs
+  exit 0
+fi
 
 while true; do
    NEW_HASH=$(md5sum $(readlink -f $file))
    if [ "$HASH" != "$NEW_HASH" ]; then
      HASH="$NEW_HASH"
      echo "[$(date +%s)] Trigger refresh"
+     set_up_configs
      kill -SIGHUP $(cat $pid); 
      echo "sent kill signal SIGHUP to $(cat $pid) with outcome $?"
    fi

--- a/config/docker/notify.sh
+++ b/config/docker/notify.sh
@@ -5,13 +5,10 @@
 ## $create_config_only is set to true to launch the script in one-shot mode (no notification loop)
 
 function set_up_configs {
-  IFACE=""
+  cp $file $dst_file
+
   if [ -n "$reachip" ]; then
     IFACE=$(ip route get $reachip | awk "/$reachip/{ print \$3 }")
-  fi
-
-  cp $file $dst_file
-  if [ -n "$IFACE" ]; then
     sed -i "s/interface.*$/interface $IFACE/g" $dst_file
     echo "autodicovered local interface that can reach $reachip to be $IFACE"
   fi

--- a/config/docker/notify.sh
+++ b/config/docker/notify.sh
@@ -1,9 +1,15 @@
-## $file contains the file to be watched
-## $pid contains the file with the PID to ne notigied with SIGHUP
-## $template contains the template to execute
-## $verb
+## $file contains the source file to be watched
+## $dst_file contains the destination file to be created from the source file
+## $reachip contains the IP to use for interface autodiscovery, or is empty if this behavior is disabled
+## $pid contains the file with the PID to be notified with SIGHUP
+## $create_config_only is set to true to launch the script in one-shot mode (no notification loop)
 
 function set_up_configs {
+  IFACE=""
+  if [ -n "$reachip" ]; then
+    IFACE=$(ip route get $reachip | awk "/$reachip/{ print \$3 }")
+  fi
+
   cp $file $dst_file
   if [ -n "$IFACE" ]; then
     sed -i "s/interface.*$/interface $IFACE/g" $dst_file
@@ -14,17 +20,12 @@ function set_up_configs {
 set -o nounset
 set -o errexit
 
-HASH=$(md5sum $(readlink -f $file))
-
-IFACE=""
-if [ -n "$reachip" ]; then
-  IFACE=$(ip route get $reachip | awk "/$reachip/{ print \$3 }")
-fi
-
-if [ "$setup" = "true" ]; then
+if [ "$create_config_only" = "true" ]; then
   set_up_configs
   exit 0
 fi
+
+HASH=$(md5sum $(readlink -f $file))
 
 while true; do
    NEW_HASH=$(md5sum $(readlink -f $file))

--- a/config/docker/notify.sh
+++ b/config/docker/notify.sh
@@ -8,7 +8,7 @@ function set_up_configs {
   cp $file $dst_file
 
   if [ -n "$reachip" ]; then
-    IFACE=$(ip route get $reachip | awk "/$reachip/{ print \$3 }")
+    IFACE=$(ip route get $reachip | grep -Po '(?<=(dev )).*(?= src| proto)')
     sed -i "s/interface.*$/interface $IFACE/g" $dst_file
     echo "autodicovered local interface that can reach $reachip to be $IFACE"
   fi

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -44,7 +44,7 @@
           {{- else }}
             value: ""
           {{- end }}
-          - name: setup
+          - name: create_config_only
             value: "true"
           volumeMounts:
           - mountPath: /etc/keepalived.d/src
@@ -107,7 +107,7 @@
           {{- else }}
             value: ""
           {{- end }}
-          - name: setup
+          - name: create_config_only
             value: "false"
           volumeMounts:
           - mountPath: /etc/keepalived.d/src

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -25,6 +25,35 @@
         automountServiceAccountToken: false
         enableServiceLinks: false
         shareProcessNamespace: true
+        initContainers:
+        - name: config-setup
+          image: {{ .Misc.image }}
+          imagePullPolicy: Always
+          command:
+          - bash
+          - -c
+          - /usr/local/bin/notify.sh
+          env:
+          - name: file
+            value: /etc/keepalived.d/src/keepalived.conf   
+          - name: dst_file
+            value: /etc/keepalived.d/dst/keepalived.conf
+          - name: reachip
+          {{- if .KeepalivedGroup.Spec.InterfaceFromIP }}
+            value: {{ .KeepalivedGroup.Spec.InterfaceFromIP }}
+          {{- else }}
+            value: ""
+          {{- end }}
+          - name: setup
+            value: "true"
+          volumeMounts:
+          - mountPath: /etc/keepalived.d/src
+            name: config
+            readOnly: true
+          - mountPath: /etc/keepalived.d/dst
+            name: config-dst
+          securityContext:
+            runAsUser: 0            
         containers:
         - name: keepalived
           image: {{ .KeepalivedGroup.Spec.Image }}
@@ -50,7 +79,7 @@
             name: lib-modules
             readOnly: true
           - mountPath: /etc/keepalived.d
-            name: config
+            name: config-dst
             readOnly: true
           - mountPath: /etc/keepalived.pid
             name: pid
@@ -69,11 +98,23 @@
           - name: pid
             value: /etc/keepalived.pid/keepalived.pid
           - name: file
-            value: /etc/keepalived.d/keepalived.conf   
+            value: /etc/keepalived.d/src/keepalived.conf   
+          - name: dst_file
+            value: /etc/keepalived.d/dst/keepalived.conf
+          - name: reachip
+          {{- if .KeepalivedGroup.Spec.InterfaceFromIP }}
+            value: {{ .KeepalivedGroup.Spec.InterfaceFromIP }}
+          {{- else }}
+            value: ""
+          {{- end }}
+          - name: setup
+            value: "false"
           volumeMounts:
-          - mountPath: /etc/keepalived.d
+          - mountPath: /etc/keepalived.d/src
             name: config
             readOnly: true
+          - mountPath: /etc/keepalived.d/dst
+            name: config-dst
           - mountPath: /etc/keepalived.pid
             name: pid
           securityContext:
@@ -107,6 +148,8 @@
         - name: config
           configMap:
             name: {{ .KeepalivedGroup.ObjectMeta.Name }}
+        - name: config-dst
+          emptyDir: {}
         - name: pid
           emptyDir:
             medium: Memory


### PR DESCRIPTION
Keepalived-operator assumes that all nodes in a given KeepalivedGroup will have the same networking configurations and the same interface names. This is not always true and it makes for a harder setup in non-homogeneous environments.

This PR introduces an extra optional field on the CRD called `interfaceFromIP`. If this field is specified, the `interface` field will be ignored and the interface name will instead be autodiscovered on each node based on which interface would be used to reach the specified IP.

This PR requires the keepalived-operator image to contain the `ip`, `sed` and `awk` binaries on the path.

This PR should address and fix #11 