### PR TITLE
Add flag to enable Unicast support

### DIFF
--- a/api/v1alpha1/keepalivedgroup_types.go
+++ b/api/v1alpha1/keepalivedgroup_types.go
@@ -56,6 +56,10 @@ type KeepalivedGroupSpec struct {
 	// // +kubebuilder:validation:UniqueItems=true
 	// +listType=set
 	BlacklistRouterIDs []int `json:"blacklistRouterIDs,omitempty"`
+
+	// +optional
+	UnicastEnabled bool `json:"unicastEnabled,omitempty"`
+
 }
 
 // PasswordAuth references a Kubernetes secret to extract the password for VRRP authentication

--- a/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
@@ -75,6 +75,8 @@ spec:
                 required:
                 - secretRef
                 type: object
+              unicastEnabled:
+                type: boolean
               verbatimConfig:
                 additionalProperties:
                   type: string

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -205,6 +205,16 @@
             {{ $ip }}
           }
 
+          {{- if eq $root.KeepalivedGroup.Spec.UnicastEnabled true }}
+          unicast_peer {
+            {{ range $pod := $root.KeepalivedPods }}
+            {{- if $pod.Status.HostIP }}
+            {{ $pod.Status.HostIP }}
+            {{- end -}}
+            {{ end }}
+          }
+          {{- end -}}
+
           {{- if ne $root.Misc.authPass "" }}
           authentication {
             auth_type PASS
@@ -234,6 +244,16 @@
             {{ . }}
             {{ end }}
           }
+
+          {{- if eq $root.KeepalivedGroup.Spec.UnicastEnabled true }}
+          unicast_peer {
+            {{ range $pod := $root.KeepalivedPods }}
+            {{- if $pod.Status.HostIP }}
+            {{ $pod.Status.HostIP }}
+            {{- end -}}
+            {{ end }}
+          }
+          {{- end -}}
 
           {{- if ne $root.Misc.authPass "" }}
           authentication {


### PR DESCRIPTION
1. adds a boolean flag to the `KeepalivedGroupSpec` called `UnicastEnabled`.
2. if `UnicastEnabled == true` render `KeepalivedPods[].Status.HostIP` under `unicast_peers {}` config in `keepalived-template.yaml`

This allows VRRP instances to only communicate with each other through direct unicast communication. This will isolate keepalived pods to their own cluster. This suits the use case where end users may have separate unrelated clusters with nodes that happen to live in the same multicast-enabled network.
