### PR TITLE
Disable AppArmor

### DIFF
--- a/api/v1alpha1/keepalivedgroup_types.go
+++ b/api/v1alpha1/keepalivedgroup_types.go
@@ -60,8 +60,9 @@ type KeepalivedGroupSpec struct {
 	// +optional
 	UnicastEnabled bool `json:"unicastEnabled,omitempty"`
 
-	// +optional
-	DisableAppArmor bool `json:"disableAppArmor,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +mapType=granular
+	DaemonsetAnnotations map[string]string `json:"daemonsetAnnotations,omitempty"`
 }
 
 // PasswordAuth references a Kubernetes secret to extract the password for VRRP authentication

--- a/api/v1alpha1/keepalivedgroup_types.go
+++ b/api/v1alpha1/keepalivedgroup_types.go
@@ -60,6 +60,8 @@ type KeepalivedGroupSpec struct {
 	// +optional
 	UnicastEnabled bool `json:"unicastEnabled,omitempty"`
 
+	// +optional
+	DisableAppArmor bool `json:"disableAppArmor,omitempty"`
 }
 
 // PasswordAuth references a Kubernetes secret to extract the password for VRRP authentication

--- a/api/v1alpha1/keepalivedgroup_types.go
+++ b/api/v1alpha1/keepalivedgroup_types.go
@@ -62,7 +62,7 @@ type KeepalivedGroupSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
-	DaemonsetAnnotations map[string]string `json:"daemonsetAnnotations,omitempty"`
+	DaemonsetPodAnnotations map[string]string `json:"daemonsetPodAnnotations,omitempty"`
 }
 
 // PasswordAuth references a Kubernetes secret to extract the password for VRRP authentication

--- a/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
@@ -41,6 +41,8 @@ spec:
                   type: integer
                 type: array
                 x-kubernetes-list-type: set
+              disableAppArmor:
+                type: boolean
               image:
                 default: registry.redhat.io/openshift4/ose-keepalived-ipfailover
                 description: //+kubebuilder:validation:Optional

--- a/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
@@ -41,8 +41,11 @@ spec:
                   type: integer
                 type: array
                 x-kubernetes-list-type: set
-              disableAppArmor:
-                type: boolean
+              daemonsetAnnotations:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-map-type: granular
               image:
                 default: registry.redhat.io/openshift4/ose-keepalived-ipfailover
                 description: //+kubebuilder:validation:Optional

--- a/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_keepalivedgroups.yaml
@@ -41,7 +41,7 @@ spec:
                   type: integer
                 type: array
                 x-kubernetes-list-type: set
-              daemonsetAnnotations:
+              daemonsetPodAnnotations:
                 additionalProperties:
                   type: string
                 type: object

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -12,6 +12,9 @@
         keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
     template:
       metadata:
+        annotations:
+          container.apparmor.security.beta.kubernetes.io/config-reloader: unconfined
+          container.apparmor.security.beta.kubernetes.io/keepalived: unconfined
         labels:
           keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
       spec:

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -12,9 +12,11 @@
         keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
     template:
       metadata:
+        {{ if .KeepalivedGroup.Spec.DisableAppArmor }}
         annotations:
           container.apparmor.security.beta.kubernetes.io/config-reloader: unconfined
           container.apparmor.security.beta.kubernetes.io/keepalived: unconfined
+        {{ end }}
         labels:
           keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
       spec:

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -12,10 +12,12 @@
         keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
     template:
       metadata:
+      {{- with .KeepalivedGroup.Spec.DaemonsetAnnotations }}
         annotations:
-        {{ range $index, $element := .KeepalivedGroup.Spec.DaemonsetPodAnnotations }}
+        {{ range $index, $element := . }}
           {{ $index }}: {{ $element }}
         {{ end }}
+      {{- end }}
         labels:
           keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
       spec:

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -12,10 +12,9 @@
         keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}
     template:
       metadata:
-        {{ if .KeepalivedGroup.Spec.DisableAppArmor }}
         annotations:
-          container.apparmor.security.beta.kubernetes.io/config-reloader: unconfined
-          container.apparmor.security.beta.kubernetes.io/keepalived: unconfined
+        {{ range $index, $element := .KeepalivedGroup.Spec.DaemonsetAnnotations }}
+          {{ $index }}: {{ $element }}
         {{ end }}
         labels:
           keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -13,7 +13,7 @@
     template:
       metadata:
         annotations:
-        {{ range $index, $element := .KeepalivedGroup.Spec.DaemonsetAnnotations }}
+        {{ range $index, $element := .KeepalivedGroup.Spec.DaemonsetPodAnnotations }}
           {{ $index }}: {{ $element }}
         {{ end }}
         labels:


### PR DESCRIPTION
I ran into "permission denied" errors within some of the daemon pod containers even when running them as root. I found that disabling AppArmor on the config-reloader and keepalived containers resolved the issue. What do you think?