### PR TITLE
Fix reconciler daemonset upsert timing issue

### DIFF
--- a/controllers/keepalivedgroup_controller.go
+++ b/controllers/keepalivedgroup_controller.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/go-logr/logr"
 	redhatcopv1alpha1 "github.com/redhat-cop/keepalived-operator/api/v1alpha1"
@@ -205,6 +206,7 @@ func (r *KeepalivedGroupReconciler) Reconcile(context context.Context, req ctrl.
 			log.Error(err, "unable to create or update resource", "resource", obj)
 			return r.ManageError(context, instance, err)
 		}
+		time.Sleep(1 * time.Second)
 	}
 	return r.ManageSuccess(context, instance)
 }


### PR DESCRIPTION
Fixing reconciler error caused by race condition between sequential daemonset updates happening too fast. Added a simple one second delay between daemonset resource upserts.

Error message was:

```
1.668550155483559e+09   ERROR   Reconciler error        {"controller": "keepalivedgroup", "controllerGroup": "redhatcop.redhat.io", "controllerKind": "KeepalivedGroup", "keepalivedGroup": {"name":"keepalivedgroup-router","namespace":"keepalived"}, "namespace": "keepalived", "name": "keepalivedgroup-router", "reconcileID": "4a801d28-def5-45a5-a5dd-b700e5513e4a", "error": "Operation cannot be fulfilled on keepalivedgroups.redhatcop.redhat.io \"keepalivedgroup-router\": the object has been modified; please apply your changes to the latest version and try again"}
```