### PR TITLE
[BUGFIX] No resource requests / limits in Daemonset template

### DIFF
--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -55,6 +55,13 @@
           {{- end }}
           - name: create_config_only
             value: "true"
+          resources:
+            limits:
+              cpu: 350m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 32Mi
           volumeMounts:
           - mountPath: /etc/keepalived.d/src
             name: config
@@ -83,6 +90,13 @@
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 350m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
           volumeMounts:
           - mountPath: /lib/modules
             name: lib-modules

--- a/config/templates/keepalived-template.yaml
+++ b/config/templates/keepalived-template.yaml
@@ -57,10 +57,10 @@
             value: "true"
           resources:
             limits:
-              cpu: 350m
+              cpu: 150m
               memory: 64Mi
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 32Mi
           volumeMounts:
           - mountPath: /etc/keepalived.d/src
@@ -132,6 +132,13 @@
           {{- end }}
           - name: create_config_only
             value: "false"
+          resources:
+            limits:
+              cpu: 150m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
           volumeMounts:
           - mountPath: /etc/keepalived.d/src
             name: config
@@ -158,6 +165,13 @@
           - name: metrics
             containerPort: 9650
             protocol: TCP  
+          resources:
+            limits:
+              cpu: 150m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
           volumeMounts:
           - mountPath: /lib/modules
             name: lib-modules


### PR DESCRIPTION
closes #131 
If a KeepalivedGroup is deployed to a namespace with resource quota, Pods will not come up due to lack of resource requests / limits. Add default values.

TODO: Update KeepalivedGroup schema to allow overriding these values.
TODO: Load tests to set better limits on resources.