### PR TITLE
[BUGFIX] Typos is README and helm templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,21 +182,19 @@ kind: ConfigMap
 metadata:
 name: keepalived-template
 namespace: {{ .KeepalivedGroup.ObjectMeta.Namespace }}
-labels:
-  keepalivedGroup: {{ .KeepalivedGroup.ObjectMeta.Name }}    
 data: 
-keepalived.conf: |
-    ...
-    # expected merge structure
-    # .KeepAlivedGroup
-    # .Services
-    - apiVersion: apps/v1
-      kind: DaemonSet
-      metadata:
-        name: {{ .KeepalivedGroup.ObjectMeta.Name }}
-        namespace: {{ .KeepalivedGroup.ObjectMeta.Namespace }}
-      spec:
-    ...
+  keepalived-template.yaml: |
+      ...
+      # expected merge structure
+      # .KeepAlivedGroup
+      # .Services
+      - apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: {{ .KeepalivedGroup.ObjectMeta.Name }}
+          namespace: {{ .KeepalivedGroup.ObjectMeta.Namespace }}
+        spec:
+      ...
 ```
   
 Then in the Helm Chart set `keepalivedTemplateFromConfigMap: keepalived-template`

--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -58,10 +58,6 @@ spec:
         env:
          {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.keepalivedTemplateFromConfigMap }}
-        - mountPath: /templates/
-          name: {{ .Values.keepalivedTemplateFromConfigMap }}
-        {{- end }}
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
@@ -77,6 +73,11 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{- if .Values.keepalivedTemplateFromConfigMap }}
+        volumeMounts:
+          - mountPath: /templates/
+            name: {{ .Values.keepalivedTemplateFromConfigMap }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
closes #130 
Helm template is missing `volumeMounts` field in `keepalivedTemplateFromConfigMap`.
README does not show correct format.